### PR TITLE
Add finalize() method to Simulation to clean the workspace

### DIFF
--- a/src/emerge/_emerge/simmodel.py
+++ b/src/emerge/_emerge/simmodel.py
@@ -478,7 +478,13 @@ class Simulation:
         """
         gmsh.write(filename)
 
-    def finalize(self):
+    def finalize(self) -> None:
+        """Clean global GMSH state and reset the Geometry Manager.
+
+        Run this method after all other operations are complete if you want to
+        interactively rerun the script in the same console or notebook. All geometry
+        data will be cleared and GMSH will be finalized.
+        """
         self._exit_gmsh()
         _GEOMANAGER.reset(self.modelname)
 


### PR DESCRIPTION
Currently, when EMerge runs it uses global state shared with GMSH and the private `_GEOMANAGER` of the `Simulation` object. If you run interactively, the workspace is not cleaned when the simulation object is apparently destroyed; the `_GEOMANAGER` maintains references, and GMSH still retains its geometry. 

This change adds a `finalize()` method to the `Simulation` class, which can be put at the end of a script to clean the state. The name `finalize()` is in analogy with the GMSH API. This method does two things:
1. It exits GMSH using `Simulation_exit_gmsh()`, cleaning the global GMSH geometry
2. It resets the `_GEOMANAGER` using `GeometryManager.reset(modelname)` for this model. (Technically there's no reason to specify the model name, because GMSH is being cleaned and all models will become invalidated anyway.)

Use the method as the last line of an example script to allow rerunning in the same console session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds an explicit manual cleanup/finalization hook for simulation runs to release resources and reset geometry state.
  * Improves stability for repeated runs and long-lived sessions (e.g., notebooks and scripts) by enabling predictable teardown and reducing lingering resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->